### PR TITLE
5 ref conftree

### DIFF
--- a/config_file/default.conf
+++ b/config_file/default.conf
@@ -2,10 +2,10 @@ server {
   listen 80;
   server_name localhost;
 
+  location / {
     error_page 500 500.html;
     error_page 404 404.html;
     error_page 403 403.html;
-  location / {
     allow_method GET;
 
     root /var/www/html;

--- a/include/ConfigTree.hpp
+++ b/include/ConfigTree.hpp
@@ -15,19 +15,19 @@ class ConfigTree {
 
         ConfigParser parser;
         ConfigNode* getRoot() const;
+
+       private:
+        int keyFlag_[16];
+        ConfigNode* root_;
+        ConfigNode* layers_[5];
+        void makeConfTree_(const ConfigParser& parser);
         void addChild(const Token& token, ConfigNode*& current,
                       ConfigNode* parent);
         void setValue(const std::string& token, ConfigNode* node);
         void addChildSetValue(const std::vector<Token>& tokens, size_t* i,
                               ConfigNode*& current, ConfigNode* parent);
-
-       private:
-        int keyFlag_[16];
-        // int depth_;
-        // int location_;
-        ConfigNode* root_;
-        ConfigNode* layers_[5];
-        void makeConfTree_(const ConfigParser& parser);
         void updateDepth_(const std::string& token, const int lineNumber);
+        void errExit_(const std::string& str1, const std::string& str2,
+                      const int number);
         void deleteTree_(ConfigNode* node);
 };

--- a/include/ConfigTree.hpp
+++ b/include/ConfigTree.hpp
@@ -3,10 +3,8 @@
 class ConfigNode;
 class ConfigParser;
 
-#include "ConfigNode.hpp"
 #include "ConfigParser.hpp"
 #include "Token.hpp"
-#include "Validator.hpp"
 
 class ConfigTree {
        public:
@@ -22,11 +20,11 @@ class ConfigTree {
         ConfigNode* layers_[5];
 
         void makeConfTree_(const ConfigParser& parser);
+        void updateDepth_(const std::string& token, const int lineNumber);
+        void resetKeyFlag_(const int keyType);
         void addChild_(const Token& token, ConfigNode*& current,
                        ConfigNode* parent);
         void setValue_(const Token& token, ConfigNode* node);
-        void updateDepth_(const std::string& token, const int lineNumber);
-        void resetKeyFlag_(const int keyType);
         void errExit_(const std::string& str1, const std::string& str2,
                       const int number);
         void deleteTree_(ConfigNode* node);

--- a/include/ConfigTree.hpp
+++ b/include/ConfigTree.hpp
@@ -20,13 +20,13 @@ class ConfigTree {
         int keyFlag_[16];
         ConfigNode* root_;
         ConfigNode* layers_[5];
+
         void makeConfTree_(const ConfigParser& parser);
-        void addChild(const Token& token, ConfigNode*& current,
-                      ConfigNode* parent);
-        void setValue(const std::string& token, ConfigNode* node);
-        void addChildSetValue(const std::vector<Token>& tokens, size_t* i,
-                              ConfigNode*& current, ConfigNode* parent);
+        void addChild_(const Token& token, ConfigNode*& current,
+                       ConfigNode* parent);
+        void setValue_(const Token& token, ConfigNode* node);
         void updateDepth_(const std::string& token, const int lineNumber);
+        void resetKeyFlag_(const int keyType);
         void errExit_(const std::string& str1, const std::string& str2,
                       const int number);
         void deleteTree_(ConfigNode* node);

--- a/include/ConfigTree.hpp
+++ b/include/ConfigTree.hpp
@@ -22,8 +22,9 @@ class ConfigTree {
                               ConfigNode*& current, ConfigNode* parent);
 
        private:
-        int depth_;
-        int location_;
+        int keyFlag_[16];
+        // int depth_;
+        // int location_;
         ConfigNode* root_;
         ConfigNode* layers_[5];
         void makeConfTree_(const ConfigParser& parser);

--- a/src/config/ConfigTree.cpp
+++ b/src/config/ConfigTree.cpp
@@ -1,7 +1,5 @@
 #include "ConfigTree.hpp"
 
-#include "ConfigParser.hpp"
-#include "Token.hpp"
 #include "Validator.hpp"
 
 ConfigTree::ConfigTree(const ConfigParser& parser) : parser(parser) {
@@ -90,7 +88,10 @@ void ConfigTree::setValue_(const Token& token, ConfigNode* node) {
 void ConfigTree::errExit_(const std::string& str1, const std::string& str2,
                           const int number) {
         std::cerr << str1 << str2 << number << std::endl;
-        deleteTree_(this->root_);
+        if (this->root_) {
+                deleteTree_(this->root_);
+                this->root_ = NULL;
+        }
         std::exit(1);
 }
 

--- a/src/config/ConfigTree.cpp
+++ b/src/config/ConfigTree.cpp
@@ -3,7 +3,7 @@
 #include "Validator.hpp"
 
 ConfigTree::ConfigTree(const ConfigParser& parser) : parser(parser) {
-        for (int i = 0; i < 16; ++i) keyFlag_[i] = 0;
+        std::fill(keyFlag_, keyFlag_ + 16, 0);
         makeConfTree_(parser);
 }
 


### PR DESCRIPTION
## 概要
- 5 configTree classの改善

## 変更内容
- 現状のclassメンバ
```c++
       public:
        explicit ConfigTree(const ConfigParser& parser);
        ~ConfigTree();

        ConfigParser parser;
        ConfigNode* getRoot() const;
        void addChild(const Token& token, ConfigNode*& current,
                      ConfigNode* parent);
        void setValue(const std::string& token, ConfigNode* node);
        void addChildSetValue(const std::vector<Token>& tokens, size_t* i,
                              ConfigNode*& current, ConfigNode* parent);

       private:
        int depth_;
        int location_;
        ConfigNode* root_;
        ConfigNode* layers_[5];
        void makeConfTree_(const ConfigParser& parser);
        void updateDepth_(const std::string& token, const int lineNumber);
        void deleteTree_(ConfigNode* node);
```
- 変更後のclassメンバ
```c++
       public:
        explicit ConfigTree(const ConfigParser& parser);
        ~ConfigTree();

        ConfigParser parser;
        ConfigNode* getRoot() const;

       private:
        int keyFlag_[16];
        ConfigNode* root_;
        ConfigNode* layers_[5];

        void makeConfTree_(const ConfigParser& parser);
        void updateDepth_(const std::string& token, const int lineNumber);
        void resetKeyFlag_(const int keyType);
        void addChild_(const Token& token, ConfigNode*& current,
                       ConfigNode* parent);
        void setValue_(const Token& token, ConfigNode* node);
        void errExit_(const std::string& str1, const std::string& str2,
                      const int number);
        void deleteTree_(ConfigNode* node);
```
- 変更点
  - int depth_, int location を削除し、int keyFlag[16];として管理する
  - addChildSetValue()を削除する
  - addChild_(), addValue_()をprivateにした
  - resetKeyFlag(key)を作成。 keyFlag[key] = 0;にリセットする
  - errExit()を作成。エラーの際、メッセージを表示し、exitする
  - 全体的にエラーの判定基準を見直した

## 影響範囲
- src/config/configTree.cpp


## その他

